### PR TITLE
Automated release with versioning tags and Open API compliance 

### DIFF
--- a/.github/workflows/model-release.yaml
+++ b/.github/workflows/model-release.yaml
@@ -1,0 +1,74 @@
+name: Model Training and Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to use (e.g., 1.0.0)'
+        required: false
+        type: string
+
+jobs:
+  train-and-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GH_TOKEN }}
+      
+      - name: Parse version info
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            VERSION="${{ inputs.version }}"
+          else
+            # GITHUB_REF is like refs/tags/v2.3.5, so strip the first 11 chars
+            VERSION=${GITHUB_REF:11}
+          fi
+          
+          if [ -z "$VERSION" ]; then
+            echo "No version provided. Using 'latest'"
+            VERSION="latest"
+          fi
+          
+          MAJOR=$(echo "$VERSION" | cut -d . -f 1)
+          MINOR=$(echo "$VERSION" | cut -d . -f 2)
+          PATCH=$(echo "$VERSION" | cut -d . -f 3)
+          echo "version=$VERSION" >> $GITHUB_ENV
+          echo "version_major=$MAJOR" >> $GITHUB_ENV
+          echo "version_minor=$MINOR" >> $GITHUB_ENV
+          echo "version_patch=$PATCH" >> $GITHUB_ENV
+      
+      - name: Train and release model
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+        run: |
+          # Set image name
+          IMG="ghcr.io/${{github.repository}}"
+          IMG=${IMG@L} # lowercase the image name
+          
+          # Build the image locally
+          docker build -t $IMG:latest .
+          
+          # Run training using the local image
+          docker run --rm \
+            -e HF_TOKEN=$HF_TOKEN \
+            $IMG:latest \
+            python train.py production --version ${{ env.version }}
+      
+      - name: Push model to GitHub Container Registry
+        run: |
+          docker build \
+          --tag $IMG:${{ env.version }} \
+          --tag $IMG:${{ env.version_major }}.${{ env.version_minor }}.latest \
+          --tag $IMG:${{ env.version_major }}.latest \
+          --tag $IMG:latest \
+          .
+          docker push --all-tags $IMG

--- a/.github/workflows/model-release.yaml
+++ b/.github/workflows/model-release.yaml
@@ -4,40 +4,16 @@ on:
   push:
     tags:
       - 'v*'
-  workflow_dispatch:
-    inputs:
-      version:
-        description: 'Version to use (e.g., 1.0.0)'
-        required: false
-        type: string
 
 jobs:
   train-and-release:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GH_TOKEN }}
-      
-      - name: Parse version info
+
+      - name: Extract version tag
         run: |
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            VERSION="${{ inputs.version }}"
-          else
-            # GITHUB_REF is like refs/tags/v2.3.5, so strip the first 11 chars
-            VERSION=${GITHUB_REF:11}
-          fi
-          
-          if [ -z "$VERSION" ]; then
-            echo "No version provided. Using 'latest'"
-            VERSION="latest"
-          fi
-          
+          VERSION=${GITHUB_REF:11}
           MAJOR=$(echo "$VERSION" | cut -d . -f 1)
           MINOR=$(echo "$VERSION" | cut -d . -f 2)
           PATCH=$(echo "$VERSION" | cut -d . -f 3)
@@ -45,6 +21,18 @@ jobs:
           echo "version_major=$MAJOR" >> $GITHUB_ENV
           echo "version_minor=$MINOR" >> $GITHUB_ENV
           echo "version_patch=$PATCH" >> $GITHUB_ENV
+      
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GH_TOKEN }}
+
+      - name: Convert repository owner to lowercase
+        id: lowercase
+        run: |
+          echo "owner=$(echo ${{ github.repository_owner }} | tr '[:upper:]' '[:lower:]')" >> $GITHUB_OUTPUT
       
       - name: Train and release model
         env:
@@ -57,18 +45,59 @@ jobs:
           # Build the image locally
           docker build -t $IMG:latest .
           
+          # Create temporary env file
+          echo "HF_TOKEN=${{ secrets.HF_TOKEN }}" > .env
+          
           # Run training using the local image
           docker run --rm \
-            -e HF_TOKEN=$HF_TOKEN \
+            --env-file .env \
             $IMG:latest \
             python train.py production --version ${{ env.version }}
+          
+          # Clean up env file
+          rm .env
       
-      - name: Push model to GitHub Container Registry
-        run: |
-          docker build \
-          --tag $IMG:${{ env.version }} \
-          --tag $IMG:${{ env.version_major }}.${{ env.version_minor }}.latest \
-          --tag $IMG:${{ env.version_major }}.latest \
-          --tag $IMG:latest \
-          .
-          docker push --all-tags $IMG
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: |
+            ghcr.io/${{ steps.lowercase.outputs.owner }}/model-training:latest
+            ghcr.io/${{ steps.lowercase.outputs.owner }}/model-training:${{ env.version }}
+            ghcr.io/${{ steps.lowercase.outputs.owner }}/model-training:${{ env.version_major }}.${{ env.version_minor }}.latest
+            ghcr.io/${{ steps.lowercase.outputs.owner }}/model-training:${{ env.version_major }}.latest
+          build-args: |
+            APP_VERSION=${{ env.version }}
+            VERSION=${{ github.ref_name }}
+    
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v1
+        with:
+          token: ${{ secrets.GH_TOKEN }}
+          draft: false
+          prerelease: ${{ contains(github.ref_name, '-pre') }}
+          name: Release ${{ github.ref_name }}
+          body: |
+            ## Docker Images
+
+            - `ghcr.io/${{ steps.lowercase.outputs.owner }}/model-training:${{ env.version }}`
+            - `ghcr.io/${{ steps.lowercase.outputs.owner }}/model-training:${{ env.version_major }}.${{ env.version_minor }}.latest`
+            - `ghcr.io/${{ steps.lowercase.outputs.owner }}/model-training:${{ env.version_major }}.latest`
+            - `ghcr.io/${{ steps.lowercase.outputs.owner }}/model-training:latest`
+
+            ## Usage
+
+            ```bash
+            # Pull specific version
+            docker pull ghcr.io/${{ steps.lowercase.outputs.owner }}/model-training:${{ env.version }}
+            
+            # Pull latest minor version
+            docker pull ghcr.io/${{ steps.lowercase.outputs.owner }}/model-training:${{ env.version_major }}.${{ env.version_minor }}.latest
+            
+            # Pull latest major version
+            docker pull ghcr.io/${{ steps.lowercase.outputs.owner }}/model-training:${{ env.version_major }}.latest
+            
+            # Pull latest version
+            docker pull ghcr.io/${{ steps.lowercase.outputs.owner }}/model-training:latest
+            ```

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ settings.json
 *__pycache__
 *.vscode
 *.pytest_cache
+.secrets

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,12 @@ WORKDIR /app
 # Copy source code
 COPY src/ .
 
-# Install dependencies from requirements.txt
-RUN pip install -r requirements.txt
+# Install git and dependencies in requirements.txt (Also clean up to reduce image size)
+RUN apt-get update && \
+    apt-get install -y git && \
+    pip install -r requirements.txt && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ To execute training and upload run:
 ```bash
 python train.py production --version <version>
 ```
-Note: You will need to have a unique version. The naming convension will follow v1, v2, v3, etc (For now theres just the version: v1).
+Note: You will need to have a unique version. The naming convension will follow v1, v2, v3, etc (For now theres just the version: v1). Additionally you must have a .env with a `HF_TOKEN` set. If you don't have access to the token you must at least have permission to create a version tag which on creation will trigger the model to be trained and uploaded to github.
 
 After uploading you can verify that it worked by running:
 ```bash

--- a/src/test_download.py
+++ b/src/test_download.py
@@ -2,17 +2,32 @@ import joblib
 import json
 import sys
 from huggingface_hub import hf_hub_download
+from typing import Tuple, Dict, Any
 
-def download_and_load_model(version):
+def download_and_load_model(version: str) -> Tuple[Any, Dict[str, Any]]:
+    """
+    Downloads and loads a model and its metadata from Hugging Face Hub.
+    
+    Args:
+        version: The version/revision of the model to download
+        
+    Returns:
+        Tuple containing:
+            - The loaded classifier model
+            - Dictionary containing the model metadata
+            
+    Raises:
+        Exception: If there are issues downloading or loading the model/metadata
+    """
     # Download model and metadata from HF Hub
     model_path = hf_hub_download(
         repo_id="todor-cmd/sentiment-classifier",
-        filename="sentiment_classifier.joblib",
+        filename="sentiment_classifier.joblib", 
         revision=version
     )
     
     metadata_path = hf_hub_download(
-        repo_id="todor-cmd/sentiment-classifier", 
+        repo_id="todor-cmd/sentiment-classifier",
         filename="metadata.json",
         revision=version
     )
@@ -26,13 +41,20 @@ def download_and_load_model(version):
 
 
 if __name__ == "__main__":
-    # Get version from command line argument if provided
-    version = sys.argv[1] 
+    if len(sys.argv) != 2:
+        print("Usage: python test_download.py <model_version>")
+        sys.exit(1)
+        
+    version = sys.argv[1]
     
-    print(f"Downloading model version: {version}")
-    classifier, metadata = download_and_load_model(version)
-    print("Successfully downloaded and loaded model!")
-    print(f"Model metadata: {metadata}")
+    try:
+        print(f"Downloading model version: {version}")
+        classifier, metadata = download_and_load_model(version)
+        print("Successfully downloaded and loaded model!")
+        print(f"Model metadata: {metadata}")
+    except Exception as e:
+        print(f"Error downloading/loading model: {str(e)}")
+        sys.exit(1)
     
     
 


### PR DESCRIPTION
Important detail. I made it so creating a tag version will in addition to the standard image releases, trigger the training and uploading of a model to hugging-face with the same version as the tag.  So these releases correlate to releases of the model on hugging-face.  Also for now the entire dataset is in the image however in the future we should look at changing this.